### PR TITLE
virt_bootstrap: Fix build with Python 3.11

### DIFF
--- a/src/virtBootstrap/virt_bootstrap.py
+++ b/src/virtBootstrap/virt_bootstrap.py
@@ -45,8 +45,7 @@ gettext.bindtextdomain("virt-bootstrap", "/usr/share/locale")
 gettext.textdomain("virt-bootstrap")
 try:
     gettext.install("virt-bootstrap",
-                    localedir="/usr/share/locale",
-                    codeset='utf-8')
+                    localedir="/usr/share/locale")
 except IOError:
     try:
         import __builtin__


### PR DESCRIPTION
The `codeset` parameter has been removed in Python version 3.11: https://docs.python.org/3.11/library/gettext.html